### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gulp-bower":           "0.0.10",
     "gulp-babel":           "5.1.0",
     "mongodb":              "2.0.28",
-    "request":              "2.55.0",
+    "request":              "2.74.0",
     "serve-favicon":        "2.2.0",
     "webpack":              "1.8.11",
     "vinyl-paths":          "1.0.0",


### PR DESCRIPTION
view.and.data-nodejs-mongo.sample currently has a 17 vulnerable dependency paths, introducing 7 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
* [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
* [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/Developer-Autodesk/view.and.data-nodejs-mongo.sample) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade other dependencies as well.

Stay Secure,
The Snyk Team